### PR TITLE
[Feat/#34] 로그아웃 API 연동 및 JWT인증 기능 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,10 +34,9 @@ const Layout = styled.div<LayoutProps>`
   height: 40px;
   width: 100%;
   // 스타일 위치
-  position: fixed;
+  /* position: fixed;
   top: 0;
-  left: 0;
-  margin-bottom: 0;
+  left: 0; */
   // 조건부로 다크모드 지정, props로 값을 받아옴
   background-color: ${(props) => (props.isDarkMode ? '#000' : '#fff')};
 `

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,10 @@
 import styled from 'styled-components'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+/*-----------------------------------------------------------*/
+import Signin from './Signin'
+/*-----------------------------------------------------------*/
 import imgDarkMode from '../assets/images/dark_mode.png'
 import imgWhiteMode from '../assets/images/white_mode.png'
 import imgLogo from '../assets/images/LOGO1.png'
@@ -6,15 +12,12 @@ import imgSignIn from '../assets/images/signin.png'
 import imgSignInDark from '../assets/images/signin_dark.png'
 import imgSignOut from '../assets/images/signout.png'
 import imgSignOutDark from '../assets/images/signout_dark.png'
-import Signin from './Signin'
-import { useState } from 'react'
 
 /*** Header 타입 지정을 위한 인터페이스 ***/
 interface HeaderProps {
   isLogin: boolean
-  onLogout?: () => void
+  // onLogout?: () => void
 }
-
 interface IconProps {
   height: string
   width: string
@@ -51,9 +54,10 @@ const Icon = styled.img<IconProps>`
   cursor: pointer;
 `
 /*** 메인 ***/
-const Header = ({ isLogin, onLogout }: HeaderProps) => {
+const Header = ({ isLogin }: HeaderProps) => {
   const [isDarkMode, setIsDarkMode] = useState(false)
   const [isSigninOpen, setIsSigninOpen] = useState(false) // SignIn 모달 상태 추가
+  const navigate = useNavigate()
 
   const handleSigninOpen = () => {
     setIsSigninOpen(true)
@@ -62,10 +66,21 @@ const Header = ({ isLogin, onLogout }: HeaderProps) => {
     setIsSigninOpen(false)
   }
   const handleDarkMode = () => {
-    console.log('dark mode state: ', isDarkMode)
-
-    setIsDarkMode((prev: boolean) => !prev) // 다크모드 상태를 토글
-    // prev : 이전 요소의 값
+    // 다크모드 토글
+    setIsDarkMode((prev: boolean) => !prev) // prev: 이전 요소의 값, 다크모드 상태를 토글
+  }
+  const handleClickSignout = async () => {
+    // 로그아웃 API 호출
+    const response = await axios.delete('http://gtd.kro.kr:8000/api/v1/auth/')
+    // 로그아웃 성공 시
+    if (response.status === 202) {
+      console.log('API Response: ', response.status)
+      alert('로그아웃 성공!')
+      // 로그아웃 성공 시, 로컬스토리지에서 토큰 삭제 후 메인페이지 이동
+      localStorage.removeItem('accessToken')
+      localStorage.removeItem('refreshToken')
+      navigate('/') // 메인페이지로 이동
+    }
   }
 
   return (
@@ -83,7 +98,7 @@ const Header = ({ isLogin, onLogout }: HeaderProps) => {
             top="12px"
             right="80px"
             alt="SignOut Icon"
-            onClick={onLogout}
+            onClick={handleClickSignout}
           />
         ) : (
           // 로그인

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -2,9 +2,7 @@ import { useState, ChangeEvent, FormEvent } from 'react'
 import styled from 'styled-components'
 import ReactModal from 'react-modal'
 import axios from 'axios'
-/*-----------------------------------------------------------*/
 import imgCloseBtn from '../assets/images/close.png'
-import imgDecoBar from '../assets/images/deco_bar.png'
 
 ReactModal.setAppElement('#root')
 
@@ -21,12 +19,12 @@ const CustomModal = {
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
 }
-const RegisterForm = styled.form`
+const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
 `
-const Title = styled.div`
+const StyledTitle = styled.div`
   font-size: 30px;
   font-weight: 400;
   font-family: 'Inter-Regular', Helvetica;
@@ -34,16 +32,39 @@ const Title = styled.div`
   margin-top: 50px;
   margin-bottom: 10px;
 `
-const Name = styled.div`
-  width: 80%;
-  font-size: 20px;
+const StyledNameWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`
+
+const StyledName = styled.span<NameProps>`
+  width: 170px;
+  float: left;
+
   font-weight: 400;
   font-family: 'Inter-Regular', Helvetica;
-  color: #000;
-  /* margin-left: 80px; */
-  margin-bottom: 5px;
+  text-align: left;
+  font-size: 20px;
+  color: black;
+
+  margin-bottom: 3px;
 `
-const Input = styled.input`
+const StyledName2 = styled.span<NameProps>`
+  width: 170px;
+  height: 20px;
+  float: right;
+
+  font-weight: 400;
+  font-family: 'Inter-Regular', Helvetica;
+  text-align: right;
+  font-size: 13px;
+  color: red;
+
+  visibility: ${(props) => props.visibility};
+  padding-top: 10px;
+  margin-bottom: 3px;
+`
+const StyledInput = styled.input`
   height: 40px;
   width: 350px;
   font-size: 15px;
@@ -53,11 +74,9 @@ const Input = styled.input`
   border-color: #000;
   border-radius: 20px;
   background-color: #fff;
-
   padding-left: 20px;
-  margin-bottom: 20px;
 `
-const Button = styled.button`
+const StyledButton = styled.button`
   height: 46px;
   width: 150px;
   border: none;
@@ -69,14 +88,13 @@ const Button = styled.button`
   font-size: 20px;
   color: #fff;
 
-  margin-bottom: 30px;
   cursor: pointer;
 
   &:hover {
     background: linear-gradient(to right, #7f58ab, #4e95b6);
   }
 `
-const CloseBtn = styled.button`
+const StyledCloseBtn = styled.button`
   position: absolute;
   top: 30px;
   right: 50px;
@@ -104,6 +122,9 @@ interface FormProps {
   password: string
   confirmPassword: string
 }
+interface NameProps {
+  visibility?: string // 비지블
+}
 /**** 메인 ****/
 function Register({ isOpen, onClose }: RegisterProps) {
   const [data, setData] = useState<FormProps>({
@@ -112,16 +133,38 @@ function Register({ isOpen, onClose }: RegisterProps) {
     password: '',
     confirmPassword: '',
   })
+  const [showError, setShowError] = useState(false)
+  // 비밀번호 불일치 시에러 메시지와 표시스타일 변경
+  const handlePasswordMismatch = () => {
+    setShowError(true)
+  }
+  // input 상태 이벤트 헨들러
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
+
     setData((prevData) => ({
       ...prevData,
       [name]: value,
     }))
+    // 비밀번호가 일치하지 않으면 상태 업데이트
+    if (name === 'confirmPassword' && data.password !== value) {
+      // 비밀번호 확인의 onChange일때만
+      // password의 value와 confirmPassword의 value와 다르면
+      handlePasswordMismatch()
+    } else {
+      // 비밀번호가 다시 일치하면 에러를 숨긴다
+      setShowError(false)
+    }
   }
-
+  // submit 이벤트 핸들러
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
+    e.preventDefault() // form요소에서 발생하는 페이지를 다시 로드하는 새로고침 방지
+
+    // 비밀번호와 비밀번호 확인의 일치 여부 확인
+    if (data.password !== data.confirmPassword) {
+      handlePasswordMismatch()
+      return // submit 중단
+    }
 
     try {
       // API 호출
@@ -132,6 +175,7 @@ function Register({ isOpen, onClose }: RegisterProps) {
       })
       // 회원가입 성공 시
       if (response.status === 200) {
+        console.log(response.data)
         console.log('API Response: ', response.status)
         alert('회원가입 성공!')
 
@@ -152,45 +196,65 @@ function Register({ isOpen, onClose }: RegisterProps) {
       onRequestClose={onClose}
       shouldCloseOnOverlayClick={false}
       style={CustomModal}>
-      <CloseBtn onClick={onClose} />
-
-      <RegisterForm onSubmit={handleSubmit}>
-        <Title>Register</Title>
-        <Name>Email</Name>
-        <Input
+      <StyledCloseBtn onClick={onClose} />
+      <StyledForm onSubmit={handleSubmit}>
+        <StyledTitle>Register</StyledTitle>
+        <StyledNameWrapper>
+          <StyledName>Email</StyledName>
+          <StyledName2 visibility="hidden">Worng Email</StyledName2>
+        </StyledNameWrapper>
+        <StyledInput
           type="email"
           name="email"
           value={data.email}
           onChange={handleChange}
           placeholder="Enter Email"
         />
-        <Name>Nickname</Name>
-        <Input
+
+        <div style={{ margin: 10 }}></div>
+        <StyledNameWrapper>
+          <StyledName>Nickname</StyledName>
+          <StyledName2 visibility="hidden">Worng Nickname</StyledName2>
+        </StyledNameWrapper>
+        <StyledInput
           type="text"
           name="nickname"
           value={data.nickname}
           onChange={handleChange}
           placeholder="Enter Nickname"
         />
-        <Name>Password</Name>
-        <Input
+
+        <div style={{ margin: 10 }}></div>
+        <StyledNameWrapper>
+          <StyledName>Password</StyledName>
+          <StyledName2 visibility="hidden">Worng Password</StyledName2>
+        </StyledNameWrapper>
+        <StyledInput
           type="password"
           name="password"
           value={data.password}
           onChange={handleChange}
           placeholder="Enter Password"
         />
-        <Name>Confirm Password</Name>
-        <Input
+
+        <div style={{ margin: 10 }}></div>
+        <StyledNameWrapper>
+          <StyledName>ConfirmPassword</StyledName>
+          <StyledName2 visibility={showError ? 'visible' : 'hidden'}>Worng Password</StyledName2>
+        </StyledNameWrapper>
+        <StyledInput
           type="password"
           name="confirmPassword"
           value={data.confirmPassword}
           onChange={handleChange}
           placeholder="Enter Confirm Password"
+          style={{
+            border: showError ? '2px solid red' : '1px solid',
+          }}
         />
-        <Button>Submit</Button>
-        <img src={imgDecoBar} alt="" />
-      </RegisterForm>
+        <div style={{ margin: 20 }}></div>
+        <StyledButton>Submit</StyledButton>
+      </StyledForm>
     </ReactModal>
   )
 }

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -1,9 +1,10 @@
 import { useState, ChangeEvent, FormEvent } from 'react'
 import styled from 'styled-components'
 import ReactModal from 'react-modal'
+import axios from 'axios'
+/*-----------------------------------------------------------*/
 import imgCloseBtn from '../assets/images/close.png'
 import imgDecoBar from '../assets/images/deco_bar.png'
-import axios from 'axios'
 
 ReactModal.setAppElement('#root')
 

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -1,15 +1,17 @@
 import { useState, ChangeEvent, FormEvent } from 'react'
 import styled from 'styled-components'
 import ReactModal from 'react-modal'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+/*-----------------------------------------------------------*/
+import Register from './Register'
+/*-----------------------------------------------------------*/
 import imgStyledCloseBtn from '../assets/images/close.png'
 import imgGoogle from '../assets/images/logo_google.png'
 import imgGithub from '../assets/images/logo_github.png'
 import imgMeta from '../assets/images/logo_meta.png'
 import imgNaver from '../assets/images/logo_naver.png'
 import imgDecoBar from '../assets/images/deco_bar.png'
-import { useNavigate } from 'react-router-dom'
-import Register from './Register'
-import axios from 'axios'
 
 ReactModal.setAppElement('#root')
 
@@ -164,6 +166,10 @@ function Signin({ isOpen, onClose }: SigninProps) {
       })
       // 로그인 성공 시
       if (response.status === 200) {
+        // 로컬 스토리지에 토큰 저장, response.data.token.[토큰이름] 은 서버에서 전달됨
+        localStorage.setItem('accessToken', response.data.token.access)
+        localStorage.setItem('refreshToken', response.data.token.refresh)
+
         console.log('API Response: ', response.status)
         alert('로그인 성공!')
 

--- a/src/pages/MyDocsPage.tsx
+++ b/src/pages/MyDocsPage.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+// import React, { useState } from 'react'
 import styled from 'styled-components'
 import Header from '../components/Header'
 import GiToDoc from '../components/mydocs/upper/GiToDoc'
@@ -14,7 +13,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100vh;
+  height: 80vh; // 헤더랑 겹쳐서 20vh 내림
   width: 100vw;
 `
 const ScrollSnap = styled.div`
@@ -48,13 +47,7 @@ const Lower = styled.div`
 
 const MyDocsPage: React.FC = () => {
   /* 로그인 이벤트 핸들러 */
-  const [isLogin, setIsLogin] = useState(true) // 기본값은 로그인이 된 상태
-  const navigate = useNavigate()
-
-  const handleLogout = () => {
-    setIsLogin(false) // 로그아웃
-    navigate('/') // 메인페이지로 이동
-  }
+  const isLogin: boolean = true // 기본값은 로그인이 된 상태
 
   /* Upper
   GiToDoc 로고 (GiToDoc)
@@ -67,7 +60,7 @@ const MyDocsPage: React.FC = () => {
 
   return (
     <Container>
-      <Header isLogin={isLogin} onLogout={handleLogout} />
+      <Header isLogin={isLogin} />
       <ScrollSnap>
         <Upper>
           <GiToDoc />

--- a/src/pages/MyDocsPage.tsx
+++ b/src/pages/MyDocsPage.tsx
@@ -13,7 +13,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 80vh; // 헤더랑 겹쳐서 20vh 내림
+  height: 100vh;
   width: 100vw;
 `
 const ScrollSnap = styled.div`
@@ -59,22 +59,24 @@ const MyDocsPage: React.FC = () => {
   */
 
   return (
-    <Container>
+    <div>
       <Header isLogin={isLogin} />
-      <ScrollSnap>
-        <Upper>
-          <GiToDoc />
-          <Description />
-          <Documentation />
-          <LanguageToggle />
-          <URLInput />
-          <RoundCarousel />
-        </Upper>
-        <Lower>
-          <Gallery />
-        </Lower>
-      </ScrollSnap>
-    </Container>
+      <Container>
+        <ScrollSnap>
+          <Upper>
+            <GiToDoc />
+            <Description />
+            <Documentation />
+            <LanguageToggle />
+            <URLInput />
+            <RoundCarousel />
+          </Upper>
+          <Lower>
+            <Gallery />
+          </Lower>
+        </ScrollSnap>
+      </Container>
+    </div>
   )
 }
 


### PR DESCRIPTION
## 📢 기능 설명

### 로그아웃 API 연동 확인
![스크린샷 2024-01-10 오후 3 18 17](https://github.com/2023WB-TeamB/Frontend/assets/111751838/5dba4133-c5d1-4421-8f01-060b653e341a)

### 로컬스토리지에 토큰 저장 확인
![스크린샷 2024-01-10 오후 3 18 02](https://github.com/2023WB-TeamB/Frontend/assets/111751838/b819ce5b-7d7c-43ca-bd4f-8d3a03cd1f54)

### 로컬스토리지의 토큰 삭제 확인
![스크린샷 2024-01-10 오후 3 18 34](https://github.com/2023WB-TeamB/Frontend/assets/111751838/f56d9d2f-43bb-4fce-9200-6ad0efb6b7e9)

### 참고
1. 로그아웃 Response Status console.log에서 202 확인
<br>

## 연결된 issue

close #34 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
