### PR TITLE
[design/#95] 로그인, 로그아웃 알림 디자인 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import Swal from 'sweetalert2'
-import { useState, useEffect } from 'react'
+// import { useState, useEffect } from 'react'
 /*----------------------------------------------------------*/
 import Signin from './Signin'
 import { useModalStore } from './useModalStore'
@@ -112,23 +112,23 @@ const Header: React.FC<HeaderType> = ({ isGetToken }) => {
     const response = await axios.delete(url)
     Swal.fire({
       // 로그아웃 알림창
-      // title: '로그아웃',
-      text: '로그아웃 하시겠습니까?',
+      title: 'Sign out',
+      text: 'Do you want to signed out?',
       icon: 'warning',
       showCancelButton: true,
       confirmButtonColor: '#3085d6',
       cancelButtonColor: '#d33',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
+      confirmButtonText: 'OK',
+      cancelButtonText: 'cancel',
     }).then((result) => {
       // 로그아웃 확인 클릭 시
       if (result.isConfirmed) {
         Swal.fire({
           // title: '로그아웃',
-          text: '로그아웃 되었습니다.',
+          text: "You're signed out of GiToDoc",
           icon: 'success',
           confirmButtonColor: '#3085d6',
-          confirmButtonText: '확인',
+          confirmButtonText: 'OK',
         })
         if (response.status === 202) {
           console.log('API Response: ', response.status)

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,14 @@
 // import { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
-import { useDarkModeStore } from '../store/store'
 import axios from 'axios'
+import Swal from 'sweetalert2'
+import { useState, useEffect } from 'react'
 /*----------------------------------------------------------*/
 import Signin from './Signin'
 import { useModalStore } from './useModalStore'
 import SearchList from './SearchList'
+import { useDarkModeStore } from '../store/store'
 /*-----------------------------------------------------------*/
 import imgDarkMode from '../assets/images/dark_mode.svg'
 import imgWhiteMode from '../assets/images/white_mode.svg'
@@ -75,8 +77,21 @@ interface SignType {
 const Header: React.FC<HeaderType> = ({ isGetToken }) => {
   const { isDarkMode, toggleDarkMode } = useDarkModeStore()
   const { isSigninOpen, toggleSignin, isSearchListOpen, searchListOpen } = useModalStore()
-  // const [scrollPosition, setScrollPosition] = useState(false) // 스크롤 위치 상태관리
+  // const [scrollPosition, setScrollPosition] = useState(0)
   const navigate = useNavigate()
+
+  // 스크롤 이벤트 핸들러 함수
+  // const handleScroll = () => {
+  //   setScrollPosition(window.scrollY)
+  // }
+  // useEffect(() => {
+  //   // 컴포넌트가 마운트되면 스크롤 이벤트 리스너 등록
+  //   window.addEventListener('scroll', handleScroll)
+  //   // 컴포넌트가 언마운트되면 이벤트 리스너 제거
+  //   return () => {
+  //     window.removeEventListener('scroll', handleScroll)
+  //   }
+  // }, []) // 빈 배열은 마운트/언마운트 시에만 실행
 
   const handleClickSignin = () => {
     toggleSignin() // 로그인 open/close 토글
@@ -95,40 +110,43 @@ const Header: React.FC<HeaderType> = ({ isGetToken }) => {
     const url = 'https://gtd.kro.kr/api/v1/auth' // 배포 서버
     // const url = 'http://localhost:8000/api/v1/auth' // 개발 서버
     const response = await axios.delete(url)
-    // 로그아웃 성공 시
-    if (response.status === 202) {
-      console.log('API Response: ', response.status)
-      // 로그아웃 성공 시, 로컬스토리지에서 토큰 삭제 후 메인페이지 이동
-      localStorage.removeItem('accessToken')
-      localStorage.removeItem('refreshToken')
-      navigate('/') // 메인페이지로 이동
-    }
+    Swal.fire({
+      // 로그아웃 알림창
+      // title: '로그아웃',
+      text: '로그아웃 하시겠습니까?',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: '확인',
+      cancelButtonText: '취소',
+    }).then((result) => {
+      // 로그아웃 확인 클릭 시
+      if (result.isConfirmed) {
+        Swal.fire({
+          // title: '로그아웃',
+          text: '로그아웃 되었습니다.',
+          icon: 'success',
+          confirmButtonColor: '#3085d6',
+          confirmButtonText: '확인',
+        })
+        if (response.status === 202) {
+          console.log('API Response: ', response.status)
+          // 로그아웃 성공 시, 로컬스토리지에서 토큰 삭제 후 메인페이지 이동
+          localStorage.removeItem('accessToken')
+          localStorage.removeItem('refreshToken')
+          navigate('/') // 메인페이지로 이동
+        }
+      }
+    })
   }
-
-  // 페이지가 닫힐 때 로그아웃 수행
-  // window.addEventListener('unload', deleteToken)
-  // function deleteToken() {
-  //   localStorage.removeItem('accessToken')
-  //   localStorage.removeItem('refreshToken')
-  // }
-
-  // 스크롤 이벤트
-  // const handleScroll = () => {
-  //   console.log(window.scrollY)
-  //   setScrollPosition(() => (window.scrollY >= 500 ? true : false))
-  // }
-  // useEffect(() => {
-  //   window.addEventListener('scroll', handleScroll)
-  //   return () => {
-  //     window.removeEventListener('scroll', handleScroll) //clean up
-  //   }
-  // })
 
   return (
     <>
       {isGetToken ? (
         <Container isDarkMode={isDarkMode}>
           <Logo src={imgLogo}></Logo>
+          {/* <span>현재 스크롤 위치: {scrollPosition}px</span> */}
           <RightWrapper>
             {/* 다크모드 */}
             <Icon

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -154,9 +154,10 @@ function Signin() {
         localStorage.setItem('refreshToken', response.data.token.refresh)
 
         console.log('API Response: ', response.status)
+
         Toast.fire({
           icon: 'success',
-          title: '환영합니다!',
+          title: 'welcome!',
         })
         toggleSignin() // 동작 수행후 모달 닫기
         navigate('/mydocs') // 마이독스 페이지로 이동
@@ -166,10 +167,17 @@ function Signin() {
       // error의 타입을 any로 명시해야함
       if (error.response.status === 400) {
         console.error('API Response: ', error.response.status)
-        Swal.fire({
+
+        // 비밀번호 초기화
+        setData((prevData) => ({
+          ...prevData,
+          password: '',
+        }))
+
+        Toast.fire({
           icon: 'error',
-          title: '로그인 실패',
-          text: '이메일 또는 비밀번호를 확인해 주세요',
+          title: 'Login failed',
+          text: 'Please check your email or password',
         })
       }
     }

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -166,9 +166,10 @@ function Signin() {
       // error의 타입을 any로 명시해야함
       if (error.response.status === 400) {
         console.error('API Response: ', error.response.status)
-        Toast.fire({
-          icon: 'success',
-          title: '다시 로그인해 주세요',
+        Swal.fire({
+          icon: 'error',
+          title: '로그인 실패',
+          text: '이메일 또는 비밀번호를 확인해 주세요',
         })
       }
     }

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -176,7 +176,7 @@ function Signin() {
 
         Toast.fire({
           icon: 'error',
-          title: 'Login failed',
+          title: 'Sign in failed',
           text: 'Please check your email or password',
         })
       }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -10,6 +10,7 @@ import { Page2 } from '../components/MainPage/page2'
 import down_arrow from '../assets/images/MainPage/down_arrow.svg'
 import { useLocalStorageStore, useModalStore } from '../components/useModalStore.tsx'
 import { useDarkModeStore } from '../store/store'
+import { useNavigate } from 'react-router-dom'
 
 /* 각 페이지에 대한 설정 */
 const Container = styled.div<{ isDarkMode: boolean }>`
@@ -153,12 +154,14 @@ const MainPage: React.FC = () => {
   const { isSigninOpen, toggleSignin } = useModalStore() // 로그인 모달 상태
   const isDarkMode = useDarkModeStore((state) => state.isDarkMode)
   const { isGetToken, setisGetToken } = useLocalStorageStore()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (localStorage.getItem('accessToken') === null) {
-      // console.log('토큰없음')
       setisGetToken(true)
-    } else setisGetToken(false)
+    } else {
+      navigate('/mydocs') // 서버 접속할 때 토큰이 저장되어있다면 로그인됨으로 간주하고 mydocs로 리다이렉션
+    }
   }, ['accessToken'])
 
   // 로그인 모달 핸들러


### PR DESCRIPTION
## 📢 기능 설명

 1. 로그인 실패 알림
![스크린샷 2024-01-23 오후 1 55 10](https://github.com/2023WB-TeamB/Frontend/assets/111751838/41be10e8-7bf3-4593-91a4-9454dee17487)
 2. 로그아웃 체크 알림
![스크린샷 2024-01-23 오후 1 54 43](https://github.com/2023WB-TeamB/Frontend/assets/111751838/c091db54-06d1-4d89-8ccf-a41f99c90c0f)
 3. 로그아웃 성공 알림
![스크린샷 2024-01-23 오후 1 54 51](https://github.com/2023WB-TeamB/Frontend/assets/111751838/ae5a8127-85e7-4a38-a7d4-44149966465e)
 4. 로그인 실패 시 패스워드 초기화
 5. GiToDoc 접속시 JWT 토큰이 존재하면  마이독스 리다이렉션 하도록 기능 추가
<br>

## 연결된 issue

close #95 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
